### PR TITLE
adapted to match new IconProvider interface

### DIFF
--- a/addons/ui/org.openhab.ui.cometvisu/OSGI-INF/cv-frontend-app.xml
+++ b/addons/ui/org.openhab.ui.cometvisu/OSGI-INF/cv-frontend-app.xml
@@ -17,7 +17,7 @@
    <reference bind="setItemUIRegistry" cardinality="1..1" interface="org.eclipse.smarthome.ui.items.ItemUIRegistry" name="ItemUIRegistry" policy="static" unbind="unsetItemUIRegistry"/>
    <reference bind="setItemRegistry" cardinality="1..1" interface="org.eclipse.smarthome.core.items.ItemRegistry" name="ItemRegistry" policy="static" unbind="unsetItemRegistry"/>
    <reference bind="addSitemapProvider" cardinality="0..n" interface="org.eclipse.smarthome.model.sitemap.SitemapProvider" name="SitemapProvider" policy="dynamic" unbind="removeSitemapProvider"/>
-   <reference bind="setIconProvider" cardinality="1..1" interface="org.eclipse.smarthome.ui.icon.IconProvider" name="IconProvider" policy="static" unbind="unsetIconProvider"/>
+   <reference bind="addIconProvider" cardinality="1..n" interface="org.eclipse.smarthome.ui.icon.IconProvider" name="IconProvider" policy="dynamic" unbind="removeIconProvider"/>
    <reference bind="addPersistenceService" cardinality="0..n" interface="org.eclipse.smarthome.core.persistence.PersistenceService" name="PersistenceService" policy="dynamic" unbind="removePersistenceService"/>
    <reference bind="setEventPublisher" cardinality="1..1" interface="org.eclipse.smarthome.core.events.EventPublisher" name="EventPublisher" policy="static" unbind="unsetEventPublisher"/>
    <property name="service.pid" type="String" value="org.openhab.cometvisu"/>

--- a/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/config/ConfigHelper.java
+++ b/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/config/ConfigHelper.java
@@ -803,7 +803,7 @@ public class ConfigHelper {
 			return getIconMapping(ohIcon);
 		} else {
 			// add the oh-icon to the icon definitions
-			if (app.getIconProvider().hasIcon(ohIcon)) {
+			if (app.hasIcon(ohIcon)) {
 				IconDefinition iconDef = factory.createIconDefinition();
 				iconDef.setUri("/images/" + ohIcon + ".png");
 				iconDef.setName("OH_" + ohIcon);
@@ -829,7 +829,7 @@ public class ConfigHelper {
 		Pagejump pagejump = new Pagejump();
 		pagejump.setBindClickToWidget(true);
 		pagejump.setTarget(targetPage.getName());
-		String ohIcon = app.getItemUIRegistry().getIcon(widget);
+		String ohIcon = app.getItemUIRegistry().getCategory(widget);
 		if (NavbarPositionType.TOP.equals(position)
 				|| NavbarPositionType.BOTTOM.equals(position)) {
 			addLabel(pagejump, targetPage.getName(),

--- a/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/servlet/CometVisuApp.java
+++ b/addons/ui/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/servlet/CometVisuApp.java
@@ -7,9 +7,7 @@
  */
 package org.openhab.ui.cometvisu.servlet;
 
-import java.io.IOException;
 import java.util.Dictionary;
-import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Hashtable;
@@ -18,19 +16,17 @@ import java.util.Set;
 
 import javax.servlet.ServletException;
 
-import org.openhab.ui.cometvisu.internal.Config;
-import org.osgi.service.cm.Configuration;
-import org.osgi.service.cm.ConfigurationException;
-import org.osgi.service.cm.ManagedService;
 import org.eclipse.smarthome.core.events.EventPublisher;
 import org.eclipse.smarthome.core.items.ItemRegistry;
 import org.eclipse.smarthome.core.persistence.PersistenceService;
 import org.eclipse.smarthome.core.persistence.QueryablePersistenceService;
 import org.eclipse.smarthome.model.sitemap.SitemapProvider;
 import org.eclipse.smarthome.ui.icon.IconProvider;
+import org.eclipse.smarthome.ui.icon.IconSet.Format;
 import org.eclipse.smarthome.ui.items.ItemUIRegistry;
+import org.openhab.ui.cometvisu.internal.Config;
 import org.osgi.framework.BundleContext;
-import org.osgi.service.cm.ConfigurationAdmin;
+import org.osgi.service.cm.ConfigurationException;
 import org.osgi.service.http.HttpService;
 import org.osgi.service.http.NamespaceException;
 import org.slf4j.Logger;
@@ -55,7 +51,7 @@ public class CometVisuApp {
 
 	private Set<SitemapProvider> sitemapProviders = new HashSet<>();
 
-	private IconProvider iconProvider;
+	private Set<IconProvider> iconProviders;
 
 	private EventPublisher eventPublisher;
 
@@ -90,16 +86,21 @@ public class CometVisuApp {
 		return persistenceServices;
 	}
 
-	public IconProvider getIconProvider() {
-		return iconProvider;
+	public boolean hasIcon(String icon) {
+	    for(IconProvider iconProvider : iconProviders) {
+	        if(iconProvider.hasIcon(icon, "classic", Format.PNG) != null) {
+	            return true;
+	        }
+	    }
+		return false;
 	}
 
-	protected void setIconProvider(IconProvider iconProvider) {
-		this.iconProvider = iconProvider;
+	protected void addIconProvider(IconProvider iconProvider) {
+		this.iconProviders.add(iconProvider);
 	}
 
 	protected void unsetIconProvider(IconProvider iconProvider) {
-		this.iconProvider = null;
+		this.iconProviders.remove(iconProvider);
 	}
 
 	protected void setItemRegistry(ItemRegistry itemRegistry) {


### PR DESCRIPTION
With https://github.com/eclipse/smarthome/pull/445, the icon infrastructure has slightly changed - there can now be multiple icon providers and some method signatures have changed as well.

This PR fixes the compilation problems, but maybe there are still problems, which you should test. The hasIcon() method expects no state on the parameter, just the pure icon name (i.e. "rollershutter" and not "rollershutter_20") - I didn't check if your code needs to be changed in this respect.
